### PR TITLE
Fix emphasis

### DIFF
--- a/app/Http/Controllers/DisciplineController.php
+++ b/app/Http/Controllers/DisciplineController.php
@@ -411,10 +411,12 @@ class DisciplineController extends Controller
 
         $classifications = Classification::all()->sortBy('order');
 
+
         if (!is_null($user)) {
             $can = $user->canDiscipline($discipline);
             return view(self::VIEW_PATH . 'show', compact('discipline', 'can'))
                 ->with('classifications', $classifications)
+                ->with('emphasis', Discipline::find($id)->emphase)
                 ->with('theme', $this->theme);
         }
 

--- a/app/Http/Controllers/DisciplineController.php
+++ b/app/Http/Controllers/DisciplineController.php
@@ -416,7 +416,6 @@ class DisciplineController extends Controller
             $can = $user->canDiscipline($discipline);
             return view(self::VIEW_PATH . 'show', compact('discipline', 'can'))
                 ->with('classifications', $classifications)
-                ->with('emphasis', Discipline::find($id)->emphase)
                 ->with('theme', $this->theme);
         }
 

--- a/app/Http/Controllers/EmphasisController.php
+++ b/app/Http/Controllers/EmphasisController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Emphasis;
 use Illuminate\Http\Request;
 
 class EmphasisController extends Controller

--- a/app/Models/Discipline.php
+++ b/app/Models/Discipline.php
@@ -158,7 +158,7 @@ class Discipline extends Model
 
     public function emphase()
     {
-        return $this->belongsTo(Emphasis::class);
+        return $this->belongsTo('App\Models\Emphasis','emphasis_id');
     }
 
     public function disciplineParticipants(){

--- a/resources/views/disciplines/show.blade.php
+++ b/resources/views/disciplines/show.blade.php
@@ -21,7 +21,9 @@ mais.
 @section('content')
 <div class='banner text-center d-flex flex-column align-items-center justify-content-center  text-white'>
     <h1 class='display-title'>{{ $discipline->name }} - {{ $discipline->code }}</h1>
-    <h3>{{ $discipline->emphasis}}</h3>
+    @if(isset($discipline->emphase) && ($discipline->emphase->name != 'Núcleo Comum'))
+    <h3>{{$discipline->emphase->name}}</h3>
+    @endif
 </div>
 @if(session('cadastroOK'))
 <div class="alert alert-success alert-dismissible fade show" role="alert">


### PR DESCRIPTION
- Corrigida a view discipline.show para exibição correta da ênfase.
- Corrigido o bug do objeto Discipline não encontrar a ênfase. Foi alterada a chave estrangeira do método belongsTo()
- para emphasis_id, na classe Discipline.